### PR TITLE
Updated App Setup File Renderer

### DIFF
--- a/tethysapp/app_store/helpers.py
+++ b/tethysapp/app_store/helpers.py
@@ -133,7 +133,7 @@ def parse_setup_file(file_location):
                             value = value[:-1]
                         params[parts[0].strip()] = value
 
-        with open(file_location) as f:
+        with open(file_location, "r") as f:
             c = f.read()
 
         setup_helper_import = re.findall("(from .* import find_all_resource_files)", c)

--- a/tethysapp/app_store/tests/files/pyproject.toml
+++ b/tethysapp/app_store/tests/files/pyproject.toml
@@ -1,0 +1,10 @@
+[project]
+name = "test_app"
+description = "example"
+long_description = "This is just an example for testing"
+license = "BSD-3"
+keywords = ["example", "test"]
+author = "Tester"
+author_email = "tester@email.com"
+version = "0.0.1"
+url = ""

--- a/tethysapp/app_store/tests/unit_tests/test_submission_handlers.py
+++ b/tethysapp/app_store/tests/unit_tests/test_submission_handlers.py
@@ -288,14 +288,14 @@ def test_create_template_data_for_install(complex_tethysapp):
     github_dir = complex_tethysapp
     dev_url = "https://github.com/notrealorg/fakeapp"
     setup_py_data = {
-        'name': 'release_package', 'version': '0.0.1', 'description': 'example',
+        'name': 'tethysapp-test_app', 'version': '0.0.1', 'description': 'example',
         'long_description': 'This is just an example for testing', 'keywords': 'example,test',
         'author': 'Tester', 'author_email': 'tester@email.com', 'url': '', 'license': 'BSD-3'
     }
     template_data = create_template_data_for_install(github_dir, dev_url, setup_py_data)
 
     expected_template_data = {
-        'metadataObj': "{'name': 'release_package', 'version': '0.0.1', 'description': 'example', "
+        'metadataObj': "{'name': 'tethysapp-test_app', 'version': '0.0.1', 'description': 'example', "
         "'long_description': 'This is just an example for testing', 'keywords': 'example,test', "
         "'author': 'Tester', 'author_email': 'tester@email.com', 'url': '', 'license': 'BSD-3', "
         "'tethys_version': '>=4.0', 'dev_url': 'https://github.com/notrealorg/fakeapp'}"


### PR DESCRIPTION
When an app is installed, the app store was checking the setup.py file to get app metadata. There was an issue with the code where variables were taken literally instead of being compiled first.

This PR fixes the issue by compiling the setup.py file to get variables values and replace the metadata where possible. The actual setup code is altered so as not to run.

Additionally this PR allows apps that use TOML files to be checked for metadata.