### PR TITLE
App Install Button Disabled During Installation

### DIFF
--- a/tethysapp/app_store/public/js/getHTML.js
+++ b/tethysapp/app_store/public/js/getHTML.js
@@ -2,20 +2,11 @@
 
 const htmlHelpers = {}
 
-htmlHelpers.versions = (appName, isUsingIncompatible) => {
-    return `<div>Which version would you like to install: 
-                    <div id="selectVersion" style="display: inline-block; min-width:100px" onchange="updateTethysPlatformVersion('${appName}', '${isUsingIncompatible}')"></div>
-                    <a class="btn btn-primary" onclick="startInstall('${appName}')"> Go </a>
-                    <br>
-                    <br>
-                    <div id="tethysPlatformVersion" style="min-width:100px"></div>
-                </div>`
-}
-htmlHelpers.versions_new = (appName,channel, label,version,isUsingIncompatible) => {
+htmlHelpers.versions = (appName, channel, label, version, isUsingIncompatible) => {
     // <div id="selectVersion" style="display: inline-block; min-width:100px" onchange="updateTethysPlatformVersion('${appName}', '${isUsingIncompatible}')"></div>
 
     return `<div>Start installation: 
-                    <a class="btn btn-primary" onclick="startInstall('${appName}','${channel}', '${label}','${version}')"> Start </a>
+                    <button id="${appName}_installer" class="btn btn-primary" onclick="startInstall('${appName}','${channel}', '${label}','${version}')"> Start </button>
                     <br>
                     <br>
                     <div id="tethysPlatformVersion" style="min-width:100px"></div>

--- a/tethysapp/app_store/public/js/main.js
+++ b/tethysapp/app_store/public/js/main.js
@@ -330,27 +330,10 @@ const updateTethysPlatformCompatibility_new = (app, selectedVersion,channel,labe
     $("#tethysPlatformVersion").text('Tethys Platform Compatibility: ' + platform_compatibility)
 }
 
-
-// const startInstall = (appName) => {
-//     showLoader()
-//     let version = $("#versions").select2("data")[0].text
-//     installRunning = true
-//     installData["version"] = version
-
-//     notification_ws.send(
-//         JSON.stringify({
-//             data: {
-//                 name: appName,
-//                 version
-//             },
-//             type: `begin_install`
-//         })
-//     )
-// }
-
 const startInstall = (appName,channel_app,label_app,current_version) => {
     showLoader()
-    // let current_version = $("#versions").select2("data")[0].text
+    $(`#${appName}_installer`).prop("disabled", true)
+    $(`#${appName}_installer`).css('opacity', '.5');
     installRunning = true
     installData["version"] = current_version
 
@@ -422,8 +405,8 @@ const update = () => {
 
     var htmlStr = `<span>`
     htmlStr += `<span class="labels_container" style="display: inline-block;"> `
-    htmlStr += `<span class="custom-label label-color-${labels_style_dict[updateData.channel]} label-outline-xs"> <i class="bi bi-shop"></i> ${updateData.channel} </span>`
-    htmlStr += `<span class="custom-label label-color-${labels_style_dict[updateData.label]} label-outline-xs"><i class="bi bi-tags"></i> ${updateData.label}</span>`
+    htmlStr += `<span class="custom-label label-color-${labels_style_dict[updateData.channel]["channel_style"]} label-outline-xs"> <i class="bi bi-shop"></i> ${updateData.channel} </span>`
+    htmlStr += `<span class="custom-label label-color-${labels_style_dict[updateData.channel]["label_styles"][updateData.label]} label-outline-xs"><i class="bi bi-tags"></i> ${updateData.label}</span>`
     htmlStr += `<span class="custom-label label-outline-xs label-color-gray">${updateData.version}</span>`
     htmlStr += `</span>`
 

--- a/tethysapp/app_store/public/js/mainTable.js
+++ b/tethysapp/app_store/public/js/mainTable.js
@@ -476,15 +476,11 @@ window.operateEvents = {
     notifCount = 0
     // Setup Versions
     let appName = row['name'];
-    // let appName = getResourceValueByName("name", row.name, appList)
     $("#installingAppName").text(appName)
     installData["name"] = appName
     let channel_and_label = get_channel_label_from_id(e);
     let selectedVersion = e.target.innerText;
-    // let versionHTML = getVersionsHTML_new(row,channel_and_label[0],channel_and_label[1])
-    n_content.append(htmlHelpers.versions_new(appName,channel_and_label[0],channel_and_label[1],selectedVersion, isUsingIncompatible))
-    // n_content.find("#selectVersion").append(versionHTML)
-    // $("#versions").select2();
+    n_content.append(htmlHelpers.versions(appName,channel_and_label[0],channel_and_label[1],selectedVersion, isUsingIncompatible))
     writeTethysPlatformCompatibility_new(e, row, channel_and_label[0],channel_and_label[1])
   },
 

--- a/tethysapp/app_store/scripts/mamba_install.sh
+++ b/tethysapp/app_store/scripts/mamba_install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 echo "Running Mamba Install"
-if hash mamba; then
+if hash micromamba; then
     MAMBA_COMMAND=micromamba
 else
     MAMBA_COMMAND=mamba


### PR DESCRIPTION
When the user begins to install an application, the user was still able to click the install button again and begin as many install processes as they wanted. With this PR, the app install button is disabled after being clicked.

Some old code was also cleaned up that wasn't being used. A bug with the mamba install script was also fixed. 