### PR TITLE
Server Error Modal Catches

### DIFF
--- a/tethysapp/app_store/begin_install.py
+++ b/tethysapp/app_store/begin_install.py
@@ -197,15 +197,14 @@ def begin_install(installData, channel_layer, app_workspace):
                       f"with label {installData['label']}", channel_layer)
     send_notification(f"Installing Version: {installData['version']}", channel_layer)
 
-    successful_install = mamba_install(resource, installData['channel'], installData['label'], installData["version"],
-                                       channel_layer)
-    if not successful_install:
-        send_notification("Error while Installing Conda package. Please check logs for details", channel_layer)
-        return
-
     try:
+        successful_install = mamba_install(resource, installData['channel'], installData['label'],
+                                           installData["version"], channel_layer)
+        if not successful_install:
+            raise Exception("Mamba install script failed to install application.")
+
         detect_app_dependencies(resource['name'], channel_layer)
     except Exception as e:
         logger.error(e)
-        send_notification("Error while checking package for services", channel_layer)
+        send_notification("Application installation failed. Check logs for more details.", channel_layer)
         return

--- a/tethysapp/app_store/public/js/utilities.js
+++ b/tethysapp/app_store/public/js/utilities.js
@@ -88,8 +88,7 @@ const sendNotification = (message, n_content) => {
       })
     )
     resetInstallStatus()
-  }
-  if (message == "Uninstall completed. Restarting server...") {
+  } else if (message == "Uninstall completed. Restarting server...") {
     inRestart = true
     notification_ws.send(
       JSON.stringify({
@@ -97,6 +96,12 @@ const sendNotification = (message, n_content) => {
         type: `restart_server`
       })
     )
+  } else if (message.includes("Application installation failed")) {
+    hideLoader()
+    $("#mainCancel").show()
+  } else if (message.includes("Application update failed")) {
+    $("#update-loader").hide()
+    $("#updateCancel").show()
   }
   n_content.append(new_element)
   $(`#install_notif_${notifCount}`).show("fast")
@@ -111,10 +116,7 @@ function startWS(websocketServerLocation, n_content) {
 
       if ("name" in uninstallData) {
         // Coming back from an uninstall restart
-        sendNotification(
-          "Server restart completed successfully",
-          $("#uninstallNotices")
-        )
+        sendNotification("Server restart completed successfully", $("#uninstallNotices"))
 
         $("#uninstallLoaderEllipsis").hide()
         $("#doneUninstallButton").show()
@@ -131,10 +133,7 @@ function startWS(websocketServerLocation, n_content) {
     if ("name" in updateData) {
       // clear out updateData
       updateData = {}
-      sendNotification(
-        "Server restart completed successfully",
-        $("#update-notices")
-      )
+      sendNotification("Server restart completed successfully",$("#update-notices"))
       $("#update-loader").hide()
       $("#done-update-button").show()
     }

--- a/tethysapp/app_store/public/js/utilities.js
+++ b/tethysapp/app_store/public/js/utilities.js
@@ -133,7 +133,7 @@ function startWS(websocketServerLocation, n_content) {
     if ("name" in updateData) {
       // clear out updateData
       updateData = {}
-      sendNotification("Server restart completed successfully",$("#update-notices"))
+      sendNotification("Server restart completed successfully", $("#update-notices"))
       $("#update-loader").hide()
       $("#done-update-button").show()
     }

--- a/tethysapp/app_store/templates/app_store/modals/update.html
+++ b/tethysapp/app_store/templates/app_store/modals/update.html
@@ -37,6 +37,7 @@
                 <button class="btn btn-danger pull-left" id="no-update" data-bs-dismiss="modal">No</button>
   
                 <button class="btn btn-success pull-right" style="margin-top:10px;display:none;" aria-hidden="true" id="done-update-button"> Done </button>
+                <button class="btn btn-outline-secondary" data-bs-dismiss="modal" aria-hidden="true" id="updateCancel"> Cancel </button>
             </div>
         </div>
     </div>

--- a/tethysapp/app_store/tests/unit_tests/test_begin_install.py
+++ b/tethysapp/app_store/tests/unit_tests/test_begin_install.py
@@ -310,37 +310,5 @@ def test_begin_install_failed_install(resource, mocker):
     mock_ws.assert_has_calls([
         call(f"Starting installation of app: {app_name} from store {app_channel} with label {app_label}", mock_channel),
         call(f"Installing Version: {app_version}", mock_channel),
-        call("Error while Installing Conda package. Please check logs for details", mock_channel)
+        call("Application installation failed. Check logs for more details.", mock_channel)
     ])
-
-
-def test_begin_install_failed_dependencies(resource, mocker, caplog):
-    mock_channel = MagicMock()
-    mock_workspace = MagicMock()
-    app_name = "test_app"
-    app_channel = "test_channel"
-    app_label = "main"
-    app_resource = resource(app_name, app_channel, app_label)
-    app_version = app_resource['latestVersion'][app_channel][app_label]
-    install_data = {
-        "name": app_name,
-        "label": app_label,
-        "channel": app_channel,
-        "version": app_version
-    }
-
-    mock_ws = mocker.patch('tethysapp.app_store.begin_install.send_notification')
-    mocker.patch('tethysapp.app_store.begin_install.get_resource', return_value=app_resource)
-    mocker.patch('tethysapp.app_store.begin_install.mamba_install', return_value=True)
-
-    with mocker.patch('tethysapp.app_store.begin_install.detect_app_dependencies',
-                      side_effect=Exception('mocked error')):
-        begin_install(install_data, mock_channel, mock_workspace)
-
-        mock_ws.assert_has_calls([
-            call(f"Starting installation of app: {app_name} from store {app_channel} with label {app_label}",
-                 mock_channel),
-            call(f"Installing Version: {app_version}", mock_channel),
-            call("Error while checking package for services", mock_channel)
-        ])
-        assert 'mocked error' in caplog.messages

--- a/tethysapp/app_store/tests/unit_tests/test_update_handlers.py
+++ b/tethysapp/app_store/tests/unit_tests/test_update_handlers.py
@@ -107,8 +107,6 @@ def test_update_app_exception(mocker, caplog):
 
     update_app(data, mock_channel, mock_workspace)
 
-    assert "Error while running conda install during the update process" in caplog.messages
     assert "Conda failed" in caplog.messages
-    mock_send_update_msg.assert_called_with("Error while Installing Conda package. Please check logs for details",
-                                            mock_channel)
+    mock_send_update_msg.assert_called_with("Application update failed. Check logs for more details.", mock_channel)
     mock_restart.assert_not_called()

--- a/tethysapp/app_store/update_handlers.py
+++ b/tethysapp/app_store/update_handlers.py
@@ -85,11 +85,9 @@ def update_app(data, channel_layer, app_workspace):
     """
     try:
         conda_update(data["name"], data["version"], data["channel"], data["label"], channel_layer)
-
     except Exception as e:
-        logger.error("Error while running conda install during the update process")
         logger.error(e)
-        send_update_msg("Error while Installing Conda package. Please check logs for details", channel_layer)
+        send_update_msg("Application update failed. Check logs for more details.", channel_layer)
         return
 
     # Since all settings are preserved, continue to standard cleanup/restart command


### PR DESCRIPTION
When a user tries to install or update an application but there is a server error, the modal would not update and continue to show the loader. This PR updates the logic so that if there is a server error on install or update, the modal is updated to let the user know, removes the loader, and adds a cancel button to get out of the modal.