### PR TITLE
Updated Settings Modal

### DIFF
--- a/tethysapp/app_store/begin_install.py
+++ b/tethysapp/app_store/begin_install.py
@@ -11,6 +11,7 @@ from subprocess import call
 
 from .helpers import check_all_present, logger, send_notification
 from .resource_helpers import get_resource, get_app_instance_from_path
+from tethys_apps.base.workspace import TethysWorkspace
 
 
 def handle_property_not_present(prop):
@@ -92,9 +93,14 @@ def detect_app_dependencies(app_name, channel_layer, notification_method=send_no
     if custom_settings:
         notification_method("Processing App's Custom Settings....", channel_layer)
         for setting in custom_settings:
+            default = setting.default
+            if isinstance(default, TethysWorkspace):
+                default = default.path
+
             setting = {"name": setting.name,
                        "description": setting.description,
-                       "default": str(setting.default),
+                       "required": setting.required,
+                       "default": str(default),
                        }
             custom_settings_json.append(setting)
 

--- a/tethysapp/app_store/public/js/main.js
+++ b/tethysapp/app_store/public/js/main.js
@@ -49,7 +49,7 @@ const settingsHelper = {
                         <label for="${setting.name}">${setting.name}${setting.required ? "*": ""}</label>
                         <input type="text" class="form-control ${requiredClass}" id="${setting.name}" value="${defaultValue}">
                         <p class="help-block">${setting.description}</p>
-                        <div id="${setting.name}_failMessage" style="display:none;margin-top:10px;margin-bottom:10px" class="p-3 mb-2 bg-warning text-white setting_warning">This setting is required and must be filled to submit settings</div>
+                        <div id="${setting.name}_warningMessage" style="display:none;margin-top:10px;margin-bottom:10px" class="p-3 mb-2 bg-warning text-white setting_warning">This setting is required and must be filled to submit settings</div>
                     </div>`
                     formDataElement.append(newElement)
                 })
@@ -71,7 +71,7 @@ const settingsHelper = {
                         .each(function() {
                             if ($(this).hasClass("required_setting") && $(this).val() == "") {
                                 let setting_name = $(this)[0].id
-                                $(`#${setting_name}_failMessage`).show()
+                                $(`#${setting_name}_warningMessage`).show()
                                 has_errors = true
                             }
                             formData.settings[$(this).attr("id")] = $(this).val()

--- a/tethysapp/app_store/public/js/main.js
+++ b/tethysapp/app_store/public/js/main.js
@@ -18,6 +18,7 @@ const settingsHelper = {
         if (settingsData) {
             if (settingsData.length > 0) {
                 $("#skipConfigButton").click(function() {
+                    $(".setting_warning").hide()
                     ws.send(
                         JSON.stringify({
                             data: {
@@ -42,11 +43,13 @@ const settingsHelper = {
                 let formDataElement = $("#custom-settings-container").children("form")
                 settingsData.forEach((setting) => {
                     let defaultValue = setting.default ? setting.default : ""
+                    let requiredClass = setting.required ? "required_setting" : ""
                     let newElement = `
                     <div class="form-group">
-                        <label for="${setting.name}">${setting.name}</label>
-                        <input type="text" class="form-control" id="${setting.name}" value="${defaultValue}">
+                        <label for="${setting.name}">${setting.name}${setting.required ? "*": ""}</label>
+                        <input type="text" class="form-control ${requiredClass}" id="${setting.name}" value="${defaultValue}">
                         <p class="help-block">${setting.description}</p>
+                        <div id="${setting.name}_failMessage" style="display:none;margin-top:10px;margin-bottom:10px" class="p-3 mb-2 bg-warning text-white setting_warning">This setting is required and must be filled to submit settings</div>
                     </div>`
                     formDataElement.append(newElement)
                 })
@@ -55,8 +58,10 @@ const settingsHelper = {
                     `<button type="submit" class="btn btn-success">Submit</button>`
                 )
                 formDataElement.submit(function(event) {
+                    $(".setting_warning").hide()
                     event.preventDefault()
                     let formData = { settings: {} }
+                    let has_errors = false
                     if ("app_py_path" in completeMessage) {
                         formData["app_py_path"] = completeMessage["app_py_path"]
                     }
@@ -64,9 +69,17 @@ const settingsHelper = {
                         .children("form")
                         .find(".form-control")
                         .each(function() {
+                            if ($(this).hasClass("required_setting") && $(this).val() == "") {
+                                let setting_name = $(this)[0].id
+                                $(`#${setting_name}_failMessage`).show()
+                                has_errors = true
+                            }
                             formData.settings[$(this).attr("id")] = $(this).val()
                         })
-
+                    
+                    if (has_errors) {
+                        return
+                    }
                     ws.send(
                         JSON.stringify({
                             data: formData,

--- a/tethysapp/app_store/templates/app_store/modals/addToWarehouse.html
+++ b/tethysapp/app_store/templates/app_store/modals/addToWarehouse.html
@@ -16,7 +16,7 @@
                     <label for="notifEmail">Notification Email</label>
                     <input type="text" class="form-control" id="notifEmail" placeholder="Email Address to notify on build">
                 </div>
-                <div id="notifEmail_failMessage" style="display:none;margin-top:10px;" class="p-3 mb-2 bg-warning text-white">A github url must be provided</div>
+                <div id="notifEmail_failMessage" style="display:none;margin-top:10px;" class="p-3 mb-2 bg-warning text-white">A email for notifications must be provided</div>
                 <div id="{{ store.conda_channel }}_failMessage" style="display:none;margin-top:10px;" class="p-3 mb-2 bg-info text-white"></div>
                 <div class="form-group">
                     <label for="githubURL">GitHub URL</label>

--- a/tethysapp/app_store/templates/app_store/modals/customSettings.html
+++ b/tethysapp/app_store/templates/app_store/modals/customSettings.html
@@ -9,6 +9,7 @@
             <div class="modal-body" id="custom-settings-container">
             </div>
             <div class="modal-footer">
+                <p>*Settings with an asterisk are required unless the configuration is skipped</p>
                 <div id="customSettingLoader" hidden>
                     <img width="100px" src="{% static 'app_store/images/loader.gif' %}" />
                 </div>


### PR DESCRIPTION
When the default value for a setting was a Tethys Workspaces, the given value to JS was causing some html issues. This PR resolves that issue by grabbing the path of the Tethys workspace if a Tethys Workspace instance is given for the default value.

This PR also adds the following functionality to the settings modal:
- If settings are required for the app, then the user is notified by an asterisk
- If a required setting is empty, then the user is warned and the app will not be submitted
- A user can skip the settings configuration still, even with a required setting