### PR TITLE
Bug Fixes from Recent Merges

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -7,4 +7,5 @@ omit =
    *urls.py,
    *wsgi.py,
    manage.py,
-   *workspaces/*
+   *workspaces/*,
+   */.tethys/*

--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
 max-line-length = 120
-exclude = tethysapp/app_store/workspaces/
+exclude = *tethysapp/app_store/workspaces/
 

--- a/tethysapp/app_store/helpers.py
+++ b/tethysapp/app_store/helpers.py
@@ -253,7 +253,7 @@ def get_conda_stores(active_only=False, conda_channels="all", sensitive_info=Fal
     for store in available_stores:
         if isinstance(store['conda_labels'], str):
             store['conda_labels'] = store['conda_labels'].split(",")
-            
+
         if not sensitive_info:
             del store['github_token']
             del store['github_organization']

--- a/tethysapp/app_store/helpers.py
+++ b/tethysapp/app_store/helpers.py
@@ -251,6 +251,9 @@ def get_conda_stores(active_only=False, conda_channels="all", sensitive_info=Fal
         available_stores = [store for store in available_stores if store['conda_channel'] in conda_channels]
 
     for store in available_stores:
+        if isinstance(store['conda_labels'], str):
+            store['conda_labels'] = store['conda_labels'].split(",")
+            
         if not sensitive_info:
             del store['github_token']
             del store['github_organization']

--- a/tethysapp/app_store/notifications.py
+++ b/tethysapp/app_store/notifications.py
@@ -62,8 +62,9 @@ class notificationsConsumer(AsyncWebsocketConsumer):
         module_name = sys.modules[__name__]
         args = [text_data_json['data'], self.channel_layer]
 
-        app_workspace_functions = ['begin_install', 'restart_server', 'get_log_file', 'process_branch'
+        app_workspace_functions = ['begin_install', 'restart_server', 'get_log_file', 'process_branch',
                                    'initialize_local_repo_for_active_stores', 'update_app', 'uninstall_app']
+
         if function_name in app_workspace_functions:
             app_workspace = await sync_to_async(get_app_workspace, thread_sensitive=True)(app)
             args.append(app_workspace)

--- a/tethysapp/app_store/public/js/addModalHelpers.js
+++ b/tethysapp/app_store/public/js/addModalHelpers.js
@@ -34,7 +34,6 @@ const addModalHelper = {
     $("#loaderEllipsis").hide()
     $("#fetchRepoButton").hide()
     $("#loadingTextAppSubmit").text("")
-    disableModalInput(disable_email=true, disable_gihuburl=true, disable_channels=true, disable_labels=true)
 
     if (!("branches" in branchesData)) {
       sendNotification(
@@ -259,7 +258,7 @@ const getRepoForAdd = () => {
   $("#loaderEllipsis").show()
   $("#fetchRepoButton").prop("disabled", true)
   $("#loadingTextAppSubmit").text("Please wait. Fetching GitHub Repo")
-  
+  disableModalInput(disable_email=true, disable_gihuburl=true, disable_channels=true, disable_labels=true)
   notification_ws.send(
       JSON.stringify({
           data: {

--- a/tethysapp/app_store/submission_handlers.py
+++ b/tethysapp/app_store/submission_handlers.py
@@ -565,7 +565,6 @@ def process_branch(install_data, channel_layer, app_workspace):
     files_changed = False
     app_github_dir = get_gitsubmission_app_dir(app_workspace, app_name, conda_channel)
     repo = git.Repo(app_github_dir)
-    setup_path = get_setup_path(app_github_dir)
 
     # 2. Get sensitive information for store
     conda_store = get_conda_stores(conda_channels=conda_channel, sensitive_info=True)[0]
@@ -580,6 +579,7 @@ def process_branch(install_data, channel_layer, app_workspace):
     origin = repo.remote(name='origin')
     repo.git.checkout(branch)
     origin.pull()
+    setup_path = get_setup_path(app_github_dir)
     setup_path_data = parse_setup_file(setup_path)
     current_version = generate_current_version(setup_path_data)
 

--- a/tethysapp/app_store/tests/unit_tests/test_installation_handlers.py
+++ b/tethysapp/app_store/tests/unit_tests/test_installation_handlers.py
@@ -19,7 +19,7 @@ def test_get_service_options(mocker):
     expected_services = [{"name": "service_setting", "id": 1}]
     assert services == expected_services
     expected_args = Namespace(spatial=True)
-    assert mock_services_list_command.called_with(expected_args)
+    mock_services_list_command.asserrt_called_with(expected_args)
 
 
 def test_restart_server_dev_server(mocker, caplog, tmp_path):


### PR DESCRIPTION
I installed tethys again on my machine and ran into a few new bugs that were introduced from the latest merges

- omit coverage from the .tethys folder. This came up when I installed tethys in development mode instead of conda
- added some code to handle store settings when conda labels are strings instead of lists
- added missing comma in app_workspace_functions list. This was causing some function to not get the app_workspace arg passed
- moved disable modal input to after the fetch repo is called instead of after the response. This was so that users can't change anything while the code is still running in the backend.
- When installing an app, I moved the get_setup_path function to after the repo is installed so the setup.py or project.toml would be present
- Fixed tests with bad assertion syntax