### PR TITLE
Submitting Apps with Existing Name

### DIFF
--- a/tethysapp/app_store/proxy_app_handlers.py
+++ b/tethysapp/app_store/proxy_app_handlers.py
@@ -136,11 +136,14 @@ def submit_proxy_app(install_data, channel_layer, app_workspace):
 
     app_name = install_data["app_name"]
     active_stores = install_data["active_stores"]
+    overwrite = install_data["overwrite"]
     proxy_app = ProxyApp.objects.get(name=app_name)
 
     for active_store in active_stores:
         submit_data = active_store
         submit_data["email"] = install_data["notification_email"]
-        submit_proxyapp_to_store(proxy_app, submit_data, channel_layer, app_workspace)
+        submit_proxyapp_to_store(
+            proxy_app, submit_data, overwrite, channel_layer, app_workspace
+        )
 
     return

--- a/tethysapp/app_store/public/js/addModalHelpers.js
+++ b/tethysapp/app_store/public/js/addModalHelpers.js
@@ -12,8 +12,7 @@ const addModalHelper = {
 
     $("#tethysapp_github_app_name_warningMessage").html(warningData.mssge_string)
     $("#tethysapp_github_app_name_warningMessage").show()
-    $("#tethysapp_appName").val(warningData.app_name)
-    $("#tethysapp_appName_div").show()
+    $("#tethysapp_overwriteApp").prop("checked", true)
     $(`#tethysapp_${warningData.conda_channel}-spinner`).hide();
     $("#submitTethysAppLoaderEllipsis").hide()
     $("#submitTethysAppLoaderText").text("")
@@ -28,7 +27,7 @@ const addModalHelper = {
     disable_options = {
       disable_email: true, disable_gihuburl: false, disable_channels: true, disable_labels: true
     }
-    disableSubmitAppModalInput("tethysapp", {disable_app_name:true})
+    disableSubmitAppModalInput("tethysapp", disable_options)
 
     if (!("branches" in branchesData)) {
       sendNotification(
@@ -68,6 +67,7 @@ const addModalHelper = {
           type: `submit_tethysapp_to_store`
         })
       )
+      disableSubmitAppModalInput("tethysapp", {disable_branches: true})
       return
     }
 
@@ -98,6 +98,7 @@ const addModalHelper = {
           type: `submit_tethysapp_to_store`
         })
       )
+      disableSubmitAppModalInput("tethysapp", {disable_branches: true})
     })
     $("#processBranchButton").show()
     // $("#failMessage").hide()
@@ -153,7 +154,7 @@ const addModalHelper = {
 const getTethysSubmitModalInput = (modal_type) => {
   let githubURL = $(`#${modal_type}_githubURL`).val()
   let notifEmail = $(`#${modal_type}_notifEmail`).val()
-  let submittedAppName = $(`#${modal_type}_appName`).val()
+  let overwriteApp = $(`#${modal_type}_overwriteApp`).prop("checked")
 
   let active_stores = []
   availableStores = $(`#${modal_type}_availableStores`).children(".row_store_submission")
@@ -178,7 +179,7 @@ const getTethysSubmitModalInput = (modal_type) => {
     active_stores.push(input_store)
   }
 
-  return [githubURL, notifEmail, submittedAppName, active_stores]
+  return [githubURL, notifEmail, overwriteApp, active_stores]
 }
 
 const disableSubmitAppModalInput = (modal_type, disable_options) => {
@@ -191,11 +192,6 @@ const disableSubmitAppModalInput = (modal_type, disable_options) => {
   if (disable_options['disable_gihuburl']) {
     SubmitAppModal.find(".githubURL").prop("disabled", true)
     SubmitAppModal.find(".githubURL").css('opacity', '.5');
-  }
-
-  if (disable_options['disable_app_name']) {
-    SubmitAppModal.find(".appName").prop("disabled", true)
-    SubmitAppModal.find(".appName").css('opacity', '.5');
   }
   
   if (disable_options['disable_channels']) {
@@ -316,7 +312,7 @@ const getRepoForAdd = () => {
   $(".label_failMessage").hide()
   $(".tethysapp_failMessage").hide()
   $(".tethysapp_warningMessage").hide()
-  let [githubURL, notifEmail, submittedAppName, active_stores] = getTethysSubmitModalInput("tethysapp")
+  let [githubURL, notifEmail, overwriteApp, active_stores] = getTethysSubmitModalInput("tethysapp")
 
   let errors = false
   if (!githubURL) {
@@ -357,7 +353,7 @@ const getRepoForAdd = () => {
           data: {
               url: githubURL,
               stores: active_stores,
-              submitted_app_name: submittedAppName
+              overwrite: overwriteApp
           },
           type: `initialize_local_repo_for_active_stores`
       })

--- a/tethysapp/app_store/public/js/addModalHelpers.js
+++ b/tethysapp/app_store/public/js/addModalHelpers.js
@@ -10,13 +10,21 @@ const addModalHelper = {
   },
   existingAppWarning: (warningData, content, completeMessage, ws ) =>{
 
-    $("#tethysapp_github_app_name_warningMessage").html(warningData.mssge_string)
-    $("#tethysapp_github_app_name_warningMessage").show()
-    $("#tethysapp_overwriteApp").prop("checked", true)
-    $(`#tethysapp_${warningData.conda_channel}-spinner`).hide();
-    $("#submitTethysAppLoaderEllipsis").hide()
-    $("#submitTethysAppLoaderText").text("")
-    $("#fetchRepoButton").prop("disabled", false)
+    let app_type = warningData.app_type
+    $(`#${app_type}_github_app_name_warningMessage`).html(warningData.mssge_string)
+    $(`#${app_type}_github_app_name_warningMessage`).show()
+    $(`#${app_type}_overwriteApp`).prop("checked", true)
+    $(`#${app_type}_${warningData.conda_channel}-spinner`).hide();
+
+    if (app_type == "tethysapp") {
+      $("#fetchRepoButton").prop("disabled", false)
+      $("#submitTethysAppLoaderEllipsis").hide()
+      $("#submitTethysAppLoaderText").text("")
+    } else if (app_type == "proxyapp") {
+      $("#submitProxyApp").prop("disabled", false)
+      $("#submitProxyAppLoaderEllipsis").hide()
+      $("#submitProxyAppLoaderText").text("")
+    }
   },
   showBranches: (branchesData, content, completeMessage, ws) => {
     // Clear loader and button:
@@ -526,9 +534,10 @@ $(document).on('click', '.proxyAppUploadToStore', function(event) {
 $(document).on('click', '#submitProxyApp', function(event) {
   $(".label_failMessage").hide()
   $(".proxyapp_failMessage").hide()
+  $(".proxyapp_warningMessage").hide()
   let submitProxyAppModal = $('#submit-proxyapp-to-store-modal')
   let proxyAppName = submitProxyAppModal.find(".modal-header").find("#submitProxyAppName")[0].innerHTML
-  let [_, notifEmail, active_stores] = getTethysSubmitModalInput("proxyapp")
+  let [_, notifEmail, overwriteApp, active_stores] = getTethysSubmitModalInput("proxyapp")
 
   let errors = false
   if (!notifEmail) {
@@ -564,7 +573,8 @@ $(document).on('click', '#submitProxyApp', function(event) {
           data: {
               app_name: proxyAppName,
               active_stores: active_stores,
-              notification_email: notifEmail
+              notification_email: notifEmail,
+              overwrite: overwriteApp
           },
           type: `submit_proxy_app`
       })

--- a/tethysapp/app_store/submission_handlers.py
+++ b/tethysapp/app_store/submission_handlers.py
@@ -101,7 +101,7 @@ def update_anaconda_dependencies(
         yaml.safe_dump(meta_yaml_file, f, default_flow_style=False)
 
 
-def get_github_repo(repo_name, organization):
+def get_github_repo(repo_name, organization, create_if_not_exist=True):
     """Retrieve the github repository. If the repository exists, use the existing repository, otherwise create a new one
 
     Args:
@@ -114,24 +114,28 @@ def get_github_repo(repo_name, organization):
     """
     try:
         tethysapp_repo = organization.get_repo(repo_name)
-        logger.info(f"{organization.login}/{repo_name} Exists. Will have to delete")
+        logger.info(f"{organization.login}/{repo_name} Exists")
         return tethysapp_repo
 
     except UnknownObjectException as e:
         logger.info(
             f"Received a {e.status} error when checking {organization.login}/{repo_name}. Error: {e.message}"
         )
-        logger.info(f"Creating a new repository at {organization.login}/{repo_name}")
-        tethysapp_repo = organization.create_repo(
-            repo_name,
-            allow_rebase_merge=True,
-            auto_init=False,
-            description="For Tethys App Store Purposes",
-            has_issues=False,
-            has_projects=False,
-            has_wiki=False,
-            private=False,
-        )
+        if create_if_not_exist:
+            logger.info(f"Creating a new repository at {organization.login}/{repo_name}")
+            tethysapp_repo = organization.create_repo(
+                repo_name,
+                allow_rebase_merge=True,
+                auto_init=False,
+                description="For Tethys App Store Purposes",
+                has_issues=False,
+                has_projects=False,
+                has_wiki=False,
+                private=False,
+            )
+        else:
+            tethysapp_repo = None
+
         return tethysapp_repo
 
 
@@ -146,8 +150,9 @@ def initialize_local_repo_for_active_stores(install_data, channel_layer, app_wor
     """
     github_url = install_data.get("url")
     stores = install_data.get("stores")
+    submitted_app_name = install_data.get("submitted_app_name")
     for store in stores:
-        initialize_local_repo(github_url, store, channel_layer, app_workspace)
+        initialize_local_repo(github_url, store, submitted_app_name, channel_layer, app_workspace)
 
 
 def get_gitsubmission_app_dir(app_workspace, app_name, conda_channel):
@@ -173,7 +178,7 @@ def get_gitsubmission_app_dir(app_workspace, app_name, conda_channel):
     return app_github_dir
 
 
-def initialize_local_repo(github_url, active_store, channel_layer, app_workspace):
+def initialize_local_repo(github_url, active_store, submitted_app_name, channel_layer, app_workspace):
     """Create and initialize a local github repo with a path for a specific conda channel. Once a repo is initialized,
     get a list of branches and send back the information to the application submission modal.
 
@@ -185,6 +190,25 @@ def initialize_local_repo(github_url, active_store, channel_layer, app_workspace
     """
     # Create/Refresh github directories within the app workspace for the given channel
     app_name = github_url.split("/")[-1].replace(".git", "")
+    conda_channel = active_store["conda_channel"]
+    conda_labels = active_store["conda_labels"]
+    
+    if check_if_remote_app_exists(app_name, conda_channel, channel_layer) and not submitted_app_name:
+        # Send notification back to websocket if remote app already exists
+        mssge_string = f"{app_name} already exists in the app store github repo. Submit again with a different name or use the same name to overwrite."
+        get_data_json = {
+            "data": {
+                "mssge_string": mssge_string,
+                "conda_channel": conda_channel,
+                "app_name": app_name
+            },
+            "jsHelperFunction": "existingAppWarning",
+            "helper": "addModalHelper",
+        }
+        send_notification(get_data_json, channel_layer)
+        return
+        
+    
     app_github_dir = get_gitsubmission_app_dir(
         app_workspace, app_name, active_store["conda_channel"]
     )
@@ -205,8 +229,8 @@ def initialize_local_repo(github_url, active_store, channel_layer, app_workspace
         "data": {
             "branches": branches,
             "app_name": app_name,
-            "conda_channel": active_store["conda_channel"],
-            "conda_labels": active_store["conda_labels"],
+            "conda_channel": conda_channel,
+            "conda_labels": conda_labels,
         },
         "jsHelperFunction": "showBranches",
         "helper": "addModalHelper",
@@ -947,16 +971,13 @@ def validate_git_credentials(github_token, conda_channel, channel_layer):
     try:
         return github.Github(github_token)
     except BadCredentialsException:
-        json_response = {}
-        json_response["next_move"] = False
         mssge_string = "Invalid git credentials. Could not connect to github. Check store settings."
         get_data_json = {
             "data": {
                 "mssge_string": mssge_string,
-                "metadata": json_response,
                 "conda_channel": conda_channel,
             },
-            "jsHelperFunction": "validationResults",
+            "jsHelperFunction": "githubValidationError",
             "helper": "addModalHelper",
         }
         send_notification(get_data_json, channel_layer)
@@ -983,20 +1004,36 @@ def validate_git_organization(
     try:
         return github_account.get_organization(github_organization)
     except BadCredentialsException:
-        json_response = {}
-        json_response["next_move"] = False
         mssge_string = "Could not connect to organization. Check store settings."
         get_data_json = {
             "data": {
                 "mssge_string": mssge_string,
-                "metadata": json_response,
                 "conda_channel": conda_channel,
             },
-            "jsHelperFunction": "validationResults",
+            "jsHelperFunction": "githubValidationError",
             "helper": "addModalHelper",
         }
         send_notification(get_data_json, channel_layer)
         raise Exception(mssge_string)
+
+
+def check_if_remote_app_exists(app_name, conda_channel, channel_layer):
+    # Get sensitive information for store
+    conda_store = get_conda_stores(conda_channels=conda_channel, sensitive_info=True)[0]
+    github_organization = conda_store["github_organization"]
+    github_token = conda_store["github_token"]
+
+    # Check to see if app exists in app store github
+    g = validate_git_credentials(github_token, conda_channel, channel_layer)
+    organization = validate_git_organization(
+        g, github_organization, conda_channel, channel_layer
+    )
+    tethysapp_repo = get_github_repo(app_name, organization, create_if_not_exist=False)
+
+    if tethysapp_repo is None:
+        return False
+    else:
+        return True
 
 
 # The functions below are not being used but may want to be implemented in the future
@@ -1162,39 +1199,6 @@ def validate_git_organization(
 #             "helper": "addModalHelper"
 #         }
 #         # send_notification(get_data_json, channel_layer)
-#     return get_data_json
-
-
-# def validation_is_new_app(github_url, app_package_name, json_response):
-#     get_data_json = {}
-#     if json_response["latest_github_url"] == github_url.replace(".git", ""):
-#         mssge_string = "<p>The submitted Github url is an update of an existing application, The app store will " \
-#                        "proceed to pull the repository</p>"
-#         json_response['next_move'] = True
-#         get_data_json = {
-#             "data": {
-#                 "mssge_string": mssge_string,
-#                 "metadata": json_response
-#             },
-#             "jsHelperFunction": "validationResults",
-#             "helper": "addModalHelper"
-#         }
-
-#     else:
-#         mssge_string = f'<p>The app_package name <b>{app_package_name}</b> of the submitted <a ' \
-#                        f'href="{github_url.replace(".git","")}">GitHub url</a> was found at an already submitted ' \
-#                        'application.</p> <ul><li>If the application is the same, please open a pull ' \
-#                        'request</li><li>If the application is not the same, please change the name of the ' \
-#                        'app_package found at the setup.py, app.py and other files</li></ul>'
-#         json_response['next_move'] = False
-#         get_data_json = {
-#             "data": {
-#                 "mssge_string": mssge_string,
-#                 "metadata": json_response
-#             },
-#             "jsHelperFunction": "validationResults",
-#             "helper": "addModalHelper"
-#         }
 #     return get_data_json
 
 

--- a/tethysapp/app_store/submission_handlers.py
+++ b/tethysapp/app_store/submission_handlers.py
@@ -150,9 +150,9 @@ def initialize_local_repo_for_active_stores(install_data, channel_layer, app_wor
     """
     github_url = install_data.get("url")
     stores = install_data.get("stores")
-    submitted_app_name = install_data.get("submitted_app_name")
+    overwrite = install_data.get("overwrite")
     for store in stores:
-        initialize_local_repo(github_url, store, submitted_app_name, channel_layer, app_workspace)
+        initialize_local_repo(github_url, store, overwrite, channel_layer, app_workspace)
 
 
 def get_gitsubmission_app_dir(app_workspace, app_name, conda_channel):
@@ -178,7 +178,7 @@ def get_gitsubmission_app_dir(app_workspace, app_name, conda_channel):
     return app_github_dir
 
 
-def initialize_local_repo(github_url, active_store, submitted_app_name, channel_layer, app_workspace):
+def initialize_local_repo(github_url, active_store, overwrite, channel_layer, app_workspace):
     """Create and initialize a local github repo with a path for a specific conda channel. Once a repo is initialized,
     get a list of branches and send back the information to the application submission modal.
 
@@ -193,9 +193,9 @@ def initialize_local_repo(github_url, active_store, submitted_app_name, channel_
     conda_channel = active_store["conda_channel"]
     conda_labels = active_store["conda_labels"]
     
-    if check_if_remote_app_exists(app_name, conda_channel, channel_layer) and not submitted_app_name:
+    if check_if_remote_app_exists(app_name, conda_channel, channel_layer) and not overwrite:
         # Send notification back to websocket if remote app already exists
-        mssge_string = f"{app_name} already exists in the app store github repo. Submit again with a different name or use the same name to overwrite."
+        mssge_string = f"{app_name} already exists in the app store github repo. Continue to overwrite or submit a new application."
         get_data_json = {
             "data": {
                 "mssge_string": mssge_string,

--- a/tethysapp/app_store/templates/app_store/modals/addProxyAppToPortal.html
+++ b/tethysapp/app_store/templates/app_store/modals/addProxyAppToPortal.html
@@ -1,12 +1,12 @@
 {% load static %}
 <div class="modal" id="add-proxyapp-to-portal-modal" style="z-index:2000;" tabindex="-1" role="dialog" aria-labelledby="add-proxyapp-to-portal-modal-label">
-    <div class="modal-dialog modal-dialog-centered" role="document">
-        <div class="modal-content">
+    <div class="modal-dialog modal-dialog-centered" style="height:90%;" role="document">
+        <div class="modal-content" style="height:100%;">
             <div class="modal-header">
                 <h5 class="modal-title" id="add-proxyapp-to-portal-modal-label">Create a proxy app for the tethys portal</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
-            <div class="modal-body" id="add-app-container">
+            <div class="modal-body" style="max-height:calc(100vh - 150px);" id="add-app-container">
                 <div>
                     <p>
                         The following form can be used to create a Tethys proxy app. Proxy apps are links to external 

--- a/tethysapp/app_store/templates/app_store/modals/submitProxyAppToStore.html
+++ b/tethysapp/app_store/templates/app_store/modals/submitProxyAppToStore.html
@@ -17,6 +17,8 @@
                 </div>
                 <div id="proxyapp_notifEmail_failMessage" style="display:none;margin-top:10px;" class="p-3 mb-2 bg-warning text-white proxyapp_failMessage">A email for notifications must be provided</div>
                 <br>
+                <div id="proxyapp_github_app_name_warningMessage" style="display:none;margin-top:10px;" class="p-3 mb-2 bg-warning text-white proxyapp_warningMessage"></div>
+                <input type="checkbox" style="display:none" id="proxyapp_overwriteApp">
                 <div id="proxyapp_availableStores">
                     <p class="title-class">Available Stores</p>
                     

--- a/tethysapp/app_store/templates/app_store/modals/submitTethysAppToStore.html
+++ b/tethysapp/app_store/templates/app_store/modals/submitTethysAppToStore.html
@@ -1,12 +1,12 @@
 {% load static %}
 <div class="modal" id="submit-tethysapp-to-store-modal" style="z-index:2000;" tabindex="-1" role="dialog" aria-labelledby="submit-tethysapp-to-store-modal-label">
-    <div class="modal-dialog modal-dialog-centered" role="document">
-        <div class="modal-content">
+    <div class="modal-dialog modal-dialog-centered" style="height:90%;" role="document">
+        <div class="modal-content" style="height:100%;">
             <div class="modal-header">
                 <h5 class="modal-title" id="submit-tethysapp-to-store-modal-label">Submit your application to the Tethys App Store</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
-            <div class="modal-body" id="add-app-container">
+            <div class="modal-body" style="max-height:calc(100vh - 150px);" id="add-app-container">
                 <div>
                     <p>
                         Click <a href="//tethys-app-store.readthedocs.io/en/latest/appsubmit.html" target="_blank">Here</a> to get instructions on how to prepare your app for submission to the app store.</p>
@@ -23,7 +23,13 @@
                     <input type="text" class="form-control githubURL" id="tethysapp_githubURL" placeholder="GitHub Repository URL">
                 </div>
                 <div id="tethysapp_githubURL_failMessage" style="display:none;margin-top:10px;" class="p-3 mb-2 bg-warning text-white tethysapp_failMessage">A github url must be provided</div>
+                <div id="tethysapp_github_app_name_warningMessage" style="display:none;margin-top:10px;" class="p-3 mb-2 bg-warning text-white tethysapp_warningMessage"></div>
                 <br>
+                <div class="form-group" id="tethysapp_appName_div" style="display:none">
+                    <label for="tethysapp_app_name">Submitted App Name</label>
+                    <input type="text" class="form-control appName" id="tethysapp_appName" placeholder="App Name">
+                    <br>
+                </div>
                 <div id="tethysapp_availableStores">
                     <p class="title-class">Available Stores</p>
                     
@@ -74,8 +80,6 @@
                     {% endfor %}
                 </div> 
                 <div id="tethysapp_{{ store.conda_channel }}_failMessage" style="display:none;margin-top:10px;" class="p-3 mb-2 bg-info text-white tethysapp_failMessage"></div>
-                <button class="btn btn-primary pull-right mt-3" id="fetchRepoButton" onClick="getRepoForAdd()"> Fetch Repository </button>
-                <button class="btn btn-primary pull-right" style="display:none;" id="processBranchButton"> Submit </button>
             </div>
             <div class="modal-footer">
                 <div id="submitTethysAppLoaderText" class="loaderText"></div>
@@ -85,7 +89,9 @@
                     <div></div>
                     <div></div>
                 </div>
-                <button class="btn btn-danger pull-left" style="margin-top:10px;" data-bs-dismiss="modal" aria-hidden="true" id="tethysappSubmitCancel"> Cancel </button>
+                <button class="btn btn-primary pull-left" style="margin-top:10px" id="fetchRepoButton" onClick="getRepoForAdd()"> Fetch Repository </button>
+                <button class="btn btn-primary pull-left" style="margin-top:10px;display:none;" id="processBranchButton"> Submit </button>
+                <button class="btn btn-danger pull-right" style="margin-top:10px;" data-bs-dismiss="modal" aria-hidden="true" id="tethysappSubmitCancel"> Cancel </button>
                 <button class="btn btn-success pull-right" style="margin-top:10px;display:none;" data-bs-dismiss="modal" aria-hidden="true" id="tethysappSubmitDone"> Done </button>
             </div>
         </div>

--- a/tethysapp/app_store/templates/app_store/modals/submitTethysAppToStore.html
+++ b/tethysapp/app_store/templates/app_store/modals/submitTethysAppToStore.html
@@ -25,11 +25,7 @@
                 <div id="tethysapp_githubURL_failMessage" style="display:none;margin-top:10px;" class="p-3 mb-2 bg-warning text-white tethysapp_failMessage">A github url must be provided</div>
                 <div id="tethysapp_github_app_name_warningMessage" style="display:none;margin-top:10px;" class="p-3 mb-2 bg-warning text-white tethysapp_warningMessage"></div>
                 <br>
-                <div class="form-group" id="tethysapp_appName_div" style="display:none">
-                    <label for="tethysapp_app_name">Submitted App Name</label>
-                    <input type="text" class="form-control appName" id="tethysapp_appName" placeholder="App Name">
-                    <br>
-                </div>
+                <input type="checkbox" style="display:none" id="tethysapp_overwriteApp">
                 <div id="tethysapp_availableStores">
                     <p class="title-class">Available Stores</p>
                     

--- a/tethysapp/app_store/templates/app_store/modals/updateProxyApp.html
+++ b/tethysapp/app_store/templates/app_store/modals/updateProxyApp.html
@@ -1,12 +1,12 @@
 {% load static %}
 <div class="modal" id="update-proxyapp-modal" style="z-index:2000;" tabindex="-1" role="dialog" aria-labelledby="update-proxyapp-modal-label">
-    <div class="modal-dialog modal-dialog-centered" role="document">
-        <div class="modal-content">
+    <div class="modal-dialog modal-dialog-centered" style="height:90%;" role="document">
+        <div class="modal-content" style="height:100%;">
             <div class="modal-header">
                 <h5 class="modal-title" id="update-proxyapp-modal-label">Update Proxy App</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
-            <div class="modal-body" id="add-app-container">
+            <div class="modal-body" style="max-height:calc(100vh - 150px);" id="add-app-container">
                 <div>
                     <p>
                         The following form can be used to Update a Tethys proxy app. Current metadata is prefilled into

--- a/tethysapp/app_store/tests/unit_tests/test_proxy_app_handlers.py
+++ b/tethysapp/app_store/tests/unit_tests/test_proxy_app_handlers.py
@@ -154,11 +154,13 @@ def test_submit_proxy_app(mocker, store, proxyapp):
     )
     app = proxyapp()
     store = store("test_store")
+    overwrite = True
     mock_proxy.objects.get.return_value = app
     install_data = {
         "app_name": "test_app",
         "notification_email": "test_email",
         "active_stores": [store],
+        "overwrite": overwrite,
     }
     mock_channel = MagicMock()
     mock_workspace = MagicMock()
@@ -167,4 +169,6 @@ def test_submit_proxy_app(mocker, store, proxyapp):
 
     submit_data = store
     submit_data["email"] = install_data["notification_email"]
-    mock_submit.assert_called_with(app, submit_data, mock_channel, mock_workspace)
+    mock_submit.assert_called_with(
+        app, submit_data, overwrite, mock_channel, mock_workspace
+    )

--- a/tethysapp/app_store/tests/unit_tests/test_submission_handlers.py
+++ b/tethysapp/app_store/tests/unit_tests/test_submission_handlers.py
@@ -722,10 +722,9 @@ def test_validate_git_credentials_bad_token(mocker):
     expected_get_data_json = {
         "data": {
             "mssge_string": "Invalid git credentials. Could not connect to github. Check store settings.",
-            "metadata": {"next_move": False},
             "conda_channel": conda_channel,
         },
-        "jsHelperFunction": "validationResults",
+        "jsHelperFunction": "githubValidationError",
         "helper": "addModalHelper",
     }
     mock_send_notification.assert_called_with(expected_get_data_json, mock_channel)
@@ -767,11 +766,10 @@ def test_validate_git_organization_bad_token(mocker):
 
     expected_get_data_json = {
         "data": {
-            "mssge_string": "Could not connect to organization. Check store settings.",
-            "metadata": {"next_move": False},
+            "mssge_string": "Could not connect to organization. Check store settings.",\
             "conda_channel": conda_channel,
         },
-        "jsHelperFunction": "validationResults",
+        "jsHelperFunction": "githubValidationError",
         "helper": "addModalHelper",
     }
     mock_send_notification.assert_called_with(expected_get_data_json, mock_channel)


### PR DESCRIPTION
Currently if an app exists in the app store github repository already and the user submits an application with the same name, the remote app will automatically get overwritten.

This PR now adds a warning to the user if an application already exists with the same name. They can continue the process though and overwrite the app if they desire, just as before.